### PR TITLE
replace Ne ST with NeST in camelcase function. Fix for UD-271

### DIFF
--- a/src/components/Results/TableBrowser/camel-case-util.js
+++ b/src/components/Results/TableBrowser/camel-case-util.js
@@ -25,6 +25,7 @@ export const camelCaseToTitleCase = (camelCaseString) => {
     .replace('Hpmi', 'HPMI')
     .replace('Ccmi', 'CCMI')
     .replace('Tcga', 'TCGA')
+    .replace('Ne ST', 'NeST')
     .replace('Querynode', 'Query Node');
   return result;
 };


### PR DESCRIPTION
Fixed network prefix in title bar for NeST networks from `Ne ST` to `NeST`